### PR TITLE
Move ApolloClient instantiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
-## Fork Me!
-This repo is a quick way to start any new project.  It comes configured with the following:
+# Property Analyzer
+[Check it out 🚀](https://property-analyzer.vercel.app/)
+
+
+This project is configured with the following:
 ### Stack
 * [NextJS](https://nextjs.org/docs/getting-started)
 * [TypeScript](https://www.typescriptlang.org/docs)
@@ -22,6 +25,7 @@ In addition, [lint-staged](https://github.com/okonet/lint-staged) and [husky](ht
 ### Tools
 * [Log Rocket](https://app.logrocket.com/)
 * [Testing Playground Chrome Extension](https://chrome.google.com/webstore/detail/testing-playground/hejbmebodbijjdhflfknehhcgaklhano?hl=en) for grabbing selectors for tests
+* [Vercel](https://vercel.com/tylerbecks/property-analyzer)
 
 ## Getting Started
 

--- a/apollo-config.ts
+++ b/apollo-config.ts
@@ -1,6 +1,0 @@
-import { ApolloClient, InMemoryCache } from '@apollo/client';
-
-export const client = new ApolloClient({
-  uri: 'https://moral-akita-32.hasura.app/v1/graphql',
-  cache: new InMemoryCache(),
-});

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -7,10 +7,10 @@ import { Provider } from 'next-auth/client';
 import type { AppProps /*, AppContext */ } from 'next/app';
 import Head from 'next/head';
 
-// import App from "next/app";
-import { client } from '../apollo-config';
 import AuthGateway from '../components/auth-gateway';
 import Layout from '../components/layout';
+import { client } from '../setup-apollo';
+// import App from "next/app";
 
 LogRocket.init('mg0tep/property-analyzer-8wicl');
 

--- a/setup-apollo.ts
+++ b/setup-apollo.ts
@@ -1,0 +1,6 @@
+import { ApolloClient, InMemoryCache, NormalizedCacheObject } from '@apollo/client';
+
+export const client: ApolloClient<NormalizedCacheObject> = new ApolloClient({
+  uri: 'https://moral-akita-32.hasura.app/v1/graphql',
+  cache: new InMemoryCache(),
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -18,12 +14,6 @@
     "isolatedModules": true,
     "jsx": "preserve"
   },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx", "babel.config.js"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "babel.config.js"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Before the ApolloClient was being instantiated in apollo-config.ts, but this file is used to configure the Apollo Studio and VS Code extension.  Moving it to setup-apollo.ts to avoid collisions in the future.