### PR TITLE
Add dynamic house pages

### DIFF
--- a/components/houses-table.tsx
+++ b/components/houses-table.tsx
@@ -2,6 +2,7 @@
 import { DeleteOutlined, EditOutlined } from '@ant-design/icons';
 import { gql, Reference, useMutation } from '@apollo/client';
 import { Button, Form, Input, InputNumber, Table, Tooltip } from 'antd';
+import Link from 'next/link';
 import { useState } from 'react';
 
 import { HOUSE_FRAGMENT } from '../fragments/house';
@@ -27,7 +28,10 @@ export const DELETE_HOUSE = gql`
 
 interface TableRecord {
   key: string;
-  name: string;
+  name: {
+    name: string;
+    id: number;
+  };
   address: {
     address1: string;
     address2: string | undefined;
@@ -42,10 +46,21 @@ interface TableRecord {
   actions: number;
 }
 
+interface UpdateHouseData {
+  name: string;
+  type: string | undefined;
+  price: number;
+  size: number;
+  notes: string | undefined;
+}
+
 const toTableRows = (houses: House[]): TableRecord[] =>
   houses.map((p, idx) => ({
     key: idx.toString(),
-    name: p.name,
+    name: {
+      name: p.name,
+      id: p.id,
+    },
     address: {
       address1: p.address1,
       address2: p.address2,
@@ -125,8 +140,8 @@ const HousesTable: React.FC<Props> = ({ houses }) => {
   const saveChanges = async (houseId: number) => {
     try {
       const row = (await form.validateFields()) as TableRecord;
-      const newHouseData = {
-        name: row.name,
+      const newHouseData: UpdateHouseData = {
+        name: row.name.name,
         type: row.type,
         price: row.price,
         size: row.size,
@@ -181,6 +196,11 @@ const HousesTable: React.FC<Props> = ({ houses }) => {
       title: 'Name',
       dataIndex: 'name',
       editable: true,
+      render: ({ id, name }: { id: number; name: string }) => (
+        <Link href={`/houses/${id}`}>
+          <a>{name}</a>
+        </Link>
+      ),
     },
     {
       title: 'Address',
@@ -269,6 +289,7 @@ const HousesTable: React.FC<Props> = ({ houses }) => {
     if (!col.editable) {
       return col;
     }
+
     return {
       ...col,
       onCell: (record: TableRecord) => ({

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -1,11 +1,17 @@
+/** @jsx jsx */
+import { css, jsx } from '@emotion/core';
 import { Layout } from 'antd';
 
 import Header from './header';
 
 const { Content } = Layout;
 
+const layoutCss = css`
+  height: 100vh;
+`;
+
 const MyLayout: React.FC = ({ children }) => (
-  <Layout>
+  <Layout css={layoutCss}>
     <Header />
 
     <Layout>

--- a/pages/houses/[propertyId].tsx
+++ b/pages/houses/[propertyId].tsx
@@ -1,0 +1,72 @@
+import { gql, useQuery } from '@apollo/client';
+import { Col, Descriptions, Empty, Row, Typography } from 'antd';
+import { useRouter } from 'next/router';
+
+import ErrorScreen from '../../components/error-screen';
+import LoadingScreen from '../../components/loading-screen';
+import { HOUSE_FRAGMENT } from '../../fragments/house';
+import { House } from '../../types/house';
+
+const { Title, Paragraph, Text } = Typography;
+
+export const GET_HOUSE_BY_ID = gql`
+  query GetHouseById($propertyId: Int!) {
+    houses_by_pk(id: $propertyId) {
+      ...House
+    }
+  }
+  ${HOUSE_FRAGMENT}
+`;
+
+const HousePage: React.FC = () => {
+  const router = useRouter();
+  const { propertyId } = router.query;
+
+  const { loading, error, data } = useQuery(GET_HOUSE_BY_ID, {
+    variables: { propertyId },
+  });
+
+  if (loading) {
+    return <LoadingScreen />;
+  }
+  if (error) {
+    return <ErrorScreen error={error} />;
+  }
+
+  const { houses_by_pk: house }: { houses_by_pk: House } = data;
+
+  return (
+    <Row>
+      <Col span={12}>
+        <Title level={2}>{house.name}</Title>
+        <Paragraph>
+          <div>
+            <Text>{house.address1}</Text>
+          </div>
+          {house.address2 && (
+            <div>
+              <Text>{house.address2}</Text>
+            </div>
+          )}
+          <div>
+            <Text>{`${house.city}, ${house.state} ${house.zip}`}</Text>
+          </div>
+        </Paragraph>
+
+        <Descriptions title="Details">
+          <Descriptions.Item label="Price">{house.price}</Descriptions.Item>
+          <Descriptions.Item label="Size">{house.size.toLocaleString()}</Descriptions.Item>
+          <Descriptions.Item label="Type">{house.type}</Descriptions.Item>
+          <Descriptions.Item label="Notes">{house.notes}</Descriptions.Item>
+        </Descriptions>
+      </Col>
+      <Col span={12}>
+        <Title level={3}>Stats</Title>
+        <Paragraph>Coming Soon</Paragraph>
+        <Empty />
+      </Col>
+    </Row>
+  );
+};
+
+export default HousePage;


### PR DESCRIPTION
Adds a link to the houses table to take users to dynamic house pages.  The house page contains basic information about the house, but will be used for the analysis.